### PR TITLE
Add support for 'on_disk' vector workload mode

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
@@ -232,4 +232,56 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       )
   }
 
+  "A KnnVectorField" should "support vector_workload and compression options" in {
+    KnnVectorFieldBuilderFn
+      .build(
+        KnnVectorField(
+          name = "myfield123",
+          dimension = 512,
+          HnswParameters(
+            engine = Some(KnnEngine.lucene),
+            spaceType = Some(SpaceType.cosine),
+            efConstruction = Some(100),
+            m = Some(50)
+          ),
+          mode = Some("on_disk"),
+          compressionLevel = Some("32x")
+        )
+      )
+      .string shouldBe
+      """{"type":"knn_vector",
+        |"dimension":512,
+        |"mode":"on_disk",
+        |"compression_level":"32x",
+        |"method":{"name":"hnsw","engine":"lucene","space_type":"cosinesimil",
+        |"parameters":{"ef_construction":100,"m":50}}}""".stripMargin.replace(
+        "\n",
+        ""
+      )
+  }
+
+  "A KnnVectorField" should "throw error when encoder is set in on_disk mode" in {
+    val exception = intercept[IllegalArgumentException](
+      KnnVectorField(
+        name = "myfield123",
+        dimension = 512,
+        parameters = HnswParameters(
+          engine = Some(KnnEngine.faiss),
+          spaceType = Some(SpaceType.l2),
+          efConstruction = Some(100),
+          m = Some(16),
+          encoder = Some(
+            FaissEncoder(
+              Some(FaissEncoderName.pq),
+              codeSize = Some(100),
+              m = Some(50)
+            )
+          )
+        ),
+        mode = Some("on_disk")
+      )
+    )
+    exception shouldBe a[RuntimeException]
+    exception.getMessage shouldBe "encoder cannot be set when using on_disk vector workload mode"
+  }
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
@@ -313,7 +313,9 @@ object IvfParameters {
 case class KnnVectorField(
     name: String,
     dimension: Int,
-    parameters: KnnMethodParameters
+    parameters: KnnMethodParameters,
+    mode: Option[String] = None,
+    compressionLevel: Option[String] = None,
 ) extends ElasticField {
   override def `type`: String = KnnVectorField.`type`
 }
@@ -324,12 +326,23 @@ object KnnVectorField {
   def apply(
       name: String,
       dimension: Int,
-      parameters: KnnMethodParameters
+      parameters: KnnMethodParameters,
+      mode: Option[String] = None,
+      compressionLevel: Option[String] = None,
   ): KnnVectorField = {
+
+    if (mode.contains("on_disk")) {
+      if (parameters.encoder.isDefined){
+        throw new IllegalArgumentException("encoder cannot be set when using on_disk vector workload mode")
+      }
+    }
+
     new KnnVectorField(
       name = name,
       dimension = dimension,
-      parameters = parameters
+      parameters = parameters,
+      mode= mode,
+      compressionLevel = compressionLevel,
     )
   }
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KnnVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KnnVectorFieldBuilderFn.scala
@@ -15,9 +15,11 @@ import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 object KnnVectorFieldBuilderFn {
   def toField(name: String, values: Map[String, Any]): KnnVectorField = {
     KnnVectorField(
-      name,
-      values.get("dimension").map(_.asInstanceOf[Int]).get,
-      (values.get("method") match {
+      name = name,
+      dimension = values.get("dimension").map(_.asInstanceOf[Int]).get,
+      mode = values.get("mode").map(_.asInstanceOf[String]),
+      compressionLevel = values.get("compressionLevel").map(_.asInstanceOf[String]),
+      parameters = (values.get("method") match {
         case Some(v) =>
           val methodFields: Map[String, Any] = v.asInstanceOf[Map[String, Any]]
           val methodName = methodFields.get("name").map(_.asInstanceOf[String])
@@ -152,7 +154,8 @@ object KnnVectorFieldBuilderFn {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)
     builder.field("dimension", field.dimension)
-
+    field.mode.foreach(v => builder.field("mode", v))
+    field.compressionLevel.foreach(v => builder.field("compression_level", v))
     // start of `method` field
     builder.startObject("method")
 


### PR DESCRIPTION
Add support for `on_disk` vector workload mode for OpenSearch KNN fields, as described in [#3596](https://github.com/magda-io/magda/issues/3596).