### PR TITLE
Snapshot/knn on disk

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
@@ -260,7 +260,7 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
             m = Some(50)
           ),
           mode = Some(VectorWorkloadMode.OnDisk),
-          compressionLevel = Some(CompressionLevel.X32)
+          compressionLevel = Some(CompressionLevel.`32x`)
         )
       )
       .string shouldBe
@@ -275,7 +275,31 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       )
   }
 
-  "A KnnVectorField" should "throw error when encoder is set in on_disk mode" in {
+  "A KnnVectorField" should "allow encoder when mode is on_disk and compressionLevel is not set" in {
+    noException shouldBe thrownBy {
+      KnnVectorField(
+        name = "myfield123",
+        dimension = 512,
+        parameters = HnswParameters(
+          engine = Some(KnnEngine.faiss),
+          spaceType = Some(SpaceType.l2),
+          efConstruction = Some(100),
+          m = Some(16),
+          encoder = Some(
+            FaissEncoder(
+              Some(FaissEncoderName.sq),
+              sqType = Some(FaissScalarQuantizationType.fp16),
+              sqClip = Some(false)
+            )
+          )
+        ),
+        mode = Some(VectorWorkloadMode.OnDisk),
+        compressionLevel = None
+      )
+    }
+  }
+
+  "A KnnVectorField" should "throw error when both encoder and compressionLevel are set" in {
     val exception = intercept[IllegalArgumentException](
       KnnVectorField(
         name = "myfield123",
@@ -293,11 +317,12 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
             )
           )
         ),
-        mode = Some(VectorWorkloadMode.OnDisk)
+        mode = Some(VectorWorkloadMode.OnDisk),
+        compressionLevel = Some(CompressionLevel.`32x`)
       )
     )
     exception shouldBe a[RuntimeException]
-    exception.getMessage shouldBe "encoder cannot be set when using on_disk vector workload mode"
+    exception.getMessage shouldBe "encoder cannot be set when compression_level is specified"
   }
 
   "A KnnVectorField" should "throw error when compression_level is not support by the engine" in {
@@ -313,7 +338,7 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
         ),
         mode = Some(VectorWorkloadMode.OnDisk),
         compressionLevel =
-          Some(CompressionLevel.X4) // only lucene supported '4x'
+          Some(CompressionLevel.`4x`) // only lucene supported '4x'
       )
     )
     exception shouldBe a[RuntimeException]

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
@@ -232,4 +232,56 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       )
   }
 
+  "A KnnVectorField" should "support vector_workload and compression options" in {
+    KnnVectorFieldBuilderFn
+      .build(
+        KnnVectorField(
+          name = "myfield123",
+          dimension = 512,
+          HnswParameters(
+            engine = Some(KnnEngine.lucene),
+            spaceType = Some(SpaceType.cosine),
+            efConstruction = Some(100),
+            m = Some(50)
+          ),
+          mode = Some("on_disk"),
+          compressionLevel = Some("32x")
+        )
+      )
+      .string shouldBe
+      """{"type":"knn_vector",
+        |"dimension":512,
+        |"mode":"on_disk",
+        |"compression_level":"32x",
+        |"method":{"name":"hnsw","engine":"lucene","space_type":"cosinesimil",
+        |"parameters":{"ef_construction":100,"m":50}}}""".stripMargin.replace(
+        "\n",
+        ""
+      )
+  }
+
+  "A KnnVectorField" should "throw error when encoder is set in on_disk mode" in {
+    val exception = intercept[IllegalArgumentException](
+      KnnVectorField(
+        name = "myfield123",
+        dimension = 512,
+        parameters = HnswParameters(
+          engine = Some(KnnEngine.faiss),
+          spaceType = Some(SpaceType.l2),
+          efConstruction = Some(100),
+          m = Some(16),
+          encoder = Some(
+            FaissEncoder(
+              Some(FaissEncoderName.pq),
+              codeSize = Some(100),
+              m = Some(50)
+            )
+          )
+        ),
+        mode = Some("on_disk")
+      )
+    )
+    exception shouldBe a[RuntimeException]
+    exception.getMessage shouldBe "encoder cannot be set when using on_disk vector workload mode"
+  }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/KnnVectorFieldTest.scala
@@ -1,7 +1,19 @@
 package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.ElasticApi
-import com.sksamuel.elastic4s.fields.{FaissEncoder, FaissEncoderName, FaissScalarQuantizationType, HnswParameters, IvfParameters, KnnEngine, KnnMethodEncoder, KnnVectorField, SpaceType}
+import com.sksamuel.elastic4s.fields.{
+  FaissEncoder,
+  FaissEncoderName,
+  FaissScalarQuantizationType,
+  HnswParameters,
+  IvfParameters,
+  KnnEngine,
+  KnnMethodEncoder,
+  KnnVectorField,
+  SpaceType,
+  VectorWorkloadMode,
+  CompressionLevel
+}
 import com.sksamuel.elastic4s.handlers.fields.KnnVectorFieldBuilderFn
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -128,10 +140,11 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
         |"dimension":512,
         |"method":{"name":"hnsw","engine":"faiss","space_type":"l2",
         |"parameters":{"ef_construction":100,"m":50,"ef_search":50,
-        |"encoder":{"name":"pq","parameters":{"m":50,"code_size":100}}}}}""".stripMargin.replace(
-        "\n",
-        ""
-      )
+        |"encoder":{"name":"pq","parameters":{"m":50,"code_size":100}}}}}""".stripMargin
+        .replace(
+          "\n",
+          ""
+        )
   }
 
   "A KnnVectorField" should "support full faiss HnswParameters (SQ)" in {
@@ -161,10 +174,11 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
         |"dimension":512,
         |"method":{"name":"hnsw","engine":"faiss","space_type":"innerproduct",
         |"parameters":{"ef_construction":100,"m":50,"ef_search":50,
-        |"encoder":{"name":"sq","parameters":{"clip":true,"type":"fp16"}}}}}""".stripMargin.replace(
-        "\n",
-        ""
-      )
+        |"encoder":{"name":"sq","parameters":{"clip":true,"type":"fp16"}}}}}""".stripMargin
+        .replace(
+          "\n",
+          ""
+        )
   }
 
   "A KnnVectorField" should "support empty IvfParameters" in {
@@ -202,10 +216,11 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
         |"dimension":512,
         |"method":{"name":"ivf","engine":"faiss","space_type":"innerproduct",
         |"parameters":{"nlist":4,"nprobes":2,
-        |"encoder":{"name":"sq","parameters":{"clip":true,"type":"fp16"}}}}}""".stripMargin.replace(
-        "\n",
-        ""
-      )
+        |"encoder":{"name":"sq","parameters":{"clip":true,"type":"fp16"}}}}}""".stripMargin
+        .replace(
+          "\n",
+          ""
+        )
   }
 
   "A KnnVectorField" should "support full lucene HnswParameters" in {
@@ -239,13 +254,13 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
           name = "myfield123",
           dimension = 512,
           HnswParameters(
-            engine = Some(KnnEngine.lucene),
-            spaceType = Some(SpaceType.cosine),
+            engine = Some(KnnEngine.faiss),
+            spaceType = Some(SpaceType.innerProduct),
             efConstruction = Some(100),
             m = Some(50)
           ),
-          mode = Some("on_disk"),
-          compressionLevel = Some("32x")
+          mode = Some(VectorWorkloadMode.OnDisk),
+          compressionLevel = Some(CompressionLevel.X32)
         )
       )
       .string shouldBe
@@ -253,7 +268,7 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
         |"dimension":512,
         |"mode":"on_disk",
         |"compression_level":"32x",
-        |"method":{"name":"hnsw","engine":"lucene","space_type":"cosinesimil",
+        |"method":{"name":"hnsw","engine":"faiss","space_type":"innerproduct",
         |"parameters":{"ef_construction":100,"m":50}}}""".stripMargin.replace(
         "\n",
         ""
@@ -278,10 +293,30 @@ class KnnVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
             )
           )
         ),
-        mode = Some("on_disk")
+        mode = Some(VectorWorkloadMode.OnDisk)
       )
     )
     exception shouldBe a[RuntimeException]
     exception.getMessage shouldBe "encoder cannot be set when using on_disk vector workload mode"
+  }
+
+  "A KnnVectorField" should "throw error when compression_level is not support by the engine" in {
+    val exception = intercept[IllegalArgumentException](
+      KnnVectorField(
+        name = "myfield123",
+        dimension = 512,
+        parameters = HnswParameters(
+          engine = Some(KnnEngine.faiss),
+          spaceType = Some(SpaceType.l2),
+          efConstruction = Some(100),
+          m = Some(16)
+        ),
+        mode = Some(VectorWorkloadMode.OnDisk),
+        compressionLevel =
+          Some(CompressionLevel.X4) // only lucene supported '4x'
+      )
+    )
+    exception shouldBe a[RuntimeException]
+    exception.getMessage shouldBe "compressionLevel 4x is not supported by engine faiss"
   }
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
@@ -313,7 +313,9 @@ object IvfParameters {
 case class KnnVectorField(
     name: String,
     dimension: Int,
-    parameters: KnnMethodParameters
+    parameters: KnnMethodParameters,
+    mode: Option[String] = None,
+    compressionLevel: Option[String] = None,
 ) extends ElasticField {
   override def `type`: String = KnnVectorField.`type`
 }
@@ -324,12 +326,23 @@ object KnnVectorField {
   def apply(
       name: String,
       dimension: Int,
-      parameters: KnnMethodParameters
+      parameters: KnnMethodParameters,
+      mode: Option[String] = None,
+      compressionLevel: Option[String] = None,
   ): KnnVectorField = {
+
+    if (mode.contains("on_disk")) {
+      if (parameters.encoder.isDefined){
+        throw new IllegalArgumentException("encoder cannot be set when using on_disk vector workload mode")
+      }
+    }
+
     new KnnVectorField(
       name = name,
       dimension = dimension,
-      parameters = parameters
+      parameters = parameters,
+      mode= mode,
+      compressionLevel = compressionLevel,
     )
   }
 

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
@@ -310,12 +310,79 @@ object IvfParameters {
   }
 }
 
+sealed trait VectorWorkloadMode {
+  def name: String
+}
+
+object VectorWorkloadMode {
+  case object InMemory extends VectorWorkloadMode {
+    val name = "in_memory"
+  }
+  case object OnDisk extends VectorWorkloadMode {
+    val name = "on_disk"
+  }
+  val values: Set[VectorWorkloadMode] = Set(InMemory, OnDisk)
+
+  def withName(name: String): VectorWorkloadMode =
+    values
+      .find(v => v.name == name)
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"Unsupported vector workload mode: $name"
+        )
+      )
+}
+
+sealed trait CompressionLevel {
+  def name: String
+  def supportedEngines: Set[KnnEngine]
+}
+
+object CompressionLevel {
+  case object X1 extends CompressionLevel {
+    val name = "1x"
+    val supportedEngines: Set[KnnEngine] =
+      Set(KnnEngine.faiss, KnnEngine.lucene, KnnEngine.nmslib)
+  }
+  case object X2 extends CompressionLevel {
+    val name = "2x"
+    val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
+  }
+  case object X4 extends CompressionLevel {
+    val name = "4x"
+    val supportedEngines: Set[KnnEngine] = Set(KnnEngine.lucene)
+  }
+  case object X8 extends CompressionLevel {
+    val name = "8x"
+    val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
+  }
+  case object X16 extends CompressionLevel {
+    val name = "16x"
+    val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
+  }
+  case object X32 extends CompressionLevel {
+    val name = "32x"
+    val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
+  }
+
+  val values: Set[CompressionLevel] = Set(X1, X2, X4, X8, X16, X32)
+
+  def withName(name: String): CompressionLevel =
+    values
+      .find(v => v.name == name)
+      .getOrElse(
+        throw new IllegalArgumentException(
+          s"Unsupported compression level: $name"
+        )
+      )
+}
+
 case class KnnVectorField(
     name: String,
     dimension: Int,
     parameters: KnnMethodParameters,
-    mode: Option[String] = None,
-    compressionLevel: Option[String] = None,
+    mode: Option[VectorWorkloadMode] = None,
+    compressionLevel: Option[CompressionLevel] = None
 ) extends ElasticField {
   override def `type`: String = KnnVectorField.`type`
 }
@@ -323,27 +390,47 @@ case class KnnVectorField(
 object KnnVectorField {
   val `type`: String = "knn_vector"
 
+  private def validate(
+      mode: Option[VectorWorkloadMode],
+      parameters: KnnMethodParameters,
+      compressionLevel: Option[CompressionLevel]
+  ): Unit = {
+    mode match {
+      case Some(VectorWorkloadMode.OnDisk) =>
+        if (parameters.encoder.isDefined) {
+          throw new IllegalArgumentException(
+            "encoder cannot be set when using on_disk vector workload mode"
+          )
+        }
+      case Some(VectorWorkloadMode.InMemory) => ()
+      case None                              => ()
+    }
+    if (compressionLevel.isDefined && parameters.engine.isDefined) {
+      val cl = compressionLevel.get
+      val engine = parameters.engine.get
+
+      if (!cl.supportedEngines.contains(engine)) {
+        throw new IllegalArgumentException(
+          s"compressionLevel ${cl.name} is not supported by engine ${engine.name}"
+        )
+      }
+    }
+  }
+
   def apply(
       name: String,
       dimension: Int,
       parameters: KnnMethodParameters,
-      mode: Option[String] = None,
-      compressionLevel: Option[String] = None,
+      mode: Option[VectorWorkloadMode] = None,
+      compressionLevel: Option[CompressionLevel] = None
   ): KnnVectorField = {
-
-    if (mode.contains("on_disk")) {
-      if (parameters.encoder.isDefined){
-        throw new IllegalArgumentException("encoder cannot be set when using on_disk vector workload mode")
-      }
-    }
-
+    validate(mode, parameters, compressionLevel)
     new KnnVectorField(
       name = name,
       dimension = dimension,
       parameters = parameters,
-      mode= mode,
-      compressionLevel = compressionLevel,
+      mode = mode,
+      compressionLevel = compressionLevel
     )
   }
-
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KnnVectorField.scala
@@ -339,33 +339,33 @@ sealed trait CompressionLevel {
 }
 
 object CompressionLevel {
-  case object X1 extends CompressionLevel {
+  case object `1x` extends CompressionLevel {
     val name = "1x"
     val supportedEngines: Set[KnnEngine] =
       Set(KnnEngine.faiss, KnnEngine.lucene, KnnEngine.nmslib)
   }
-  case object X2 extends CompressionLevel {
+  case object `2x` extends CompressionLevel {
     val name = "2x"
     val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
   }
-  case object X4 extends CompressionLevel {
+  case object `4x` extends CompressionLevel {
     val name = "4x"
     val supportedEngines: Set[KnnEngine] = Set(KnnEngine.lucene)
   }
-  case object X8 extends CompressionLevel {
+  case object `8x` extends CompressionLevel {
     val name = "8x"
     val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
   }
-  case object X16 extends CompressionLevel {
+  case object `16x` extends CompressionLevel {
     val name = "16x"
     val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
   }
-  case object X32 extends CompressionLevel {
+  case object `32x` extends CompressionLevel {
     val name = "32x"
     val supportedEngines: Set[KnnEngine] = Set(KnnEngine.faiss)
   }
 
-  val values: Set[CompressionLevel] = Set(X1, X2, X4, X8, X16, X32)
+  val values: Set[CompressionLevel] = Set(`1x`, `2x`, `4x`, `8x`, `16x`, `32x`)
 
   def withName(name: String): CompressionLevel =
     values
@@ -395,16 +395,12 @@ object KnnVectorField {
       parameters: KnnMethodParameters,
       compressionLevel: Option[CompressionLevel]
   ): Unit = {
-    mode match {
-      case Some(VectorWorkloadMode.OnDisk) =>
-        if (parameters.encoder.isDefined) {
-          throw new IllegalArgumentException(
-            "encoder cannot be set when using on_disk vector workload mode"
-          )
-        }
-      case Some(VectorWorkloadMode.InMemory) => ()
-      case None                              => ()
+    if (compressionLevel.isDefined && parameters.encoder.isDefined) {
+      throw new IllegalArgumentException(
+        "encoder cannot be set when compression_level is specified"
+      )
     }
+
     if (compressionLevel.isDefined && parameters.engine.isDefined) {
       val cl = compressionLevel.get
       val engine = parameters.engine.get

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KnnVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KnnVectorFieldBuilderFn.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.handlers.fields
 
 import com.sksamuel.elastic4s.fields.{
+  CompressionLevel,
   FaissEncoder,
   FaissEncoderName,
   FaissScalarQuantizationType,
@@ -8,7 +9,8 @@ import com.sksamuel.elastic4s.fields.{
   IvfParameters,
   KnnEngine,
   KnnVectorField,
-  SpaceType
+  SpaceType,
+  VectorWorkloadMode
 }
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
@@ -17,8 +19,14 @@ object KnnVectorFieldBuilderFn {
     KnnVectorField(
       name = name,
       dimension = values.get("dimension").map(_.asInstanceOf[Int]).get,
-      mode = values.get("mode").map(_.asInstanceOf[String]),
-      compressionLevel = values.get("compressionLevel").map(_.asInstanceOf[String]),
+      mode = values
+        .get("mode")
+        .map(_.asInstanceOf[String])
+        .flatMap(v => Some(VectorWorkloadMode.withName(v))),
+      compressionLevel = values
+        .get("compressionLevel")
+        .map(_.asInstanceOf[String])
+        .flatMap(v => Some(CompressionLevel.withName(v))),
       parameters = (values.get("method") match {
         case Some(v) =>
           val methodFields: Map[String, Any] = v.asInstanceOf[Map[String, Any]]
@@ -154,8 +162,10 @@ object KnnVectorFieldBuilderFn {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)
     builder.field("dimension", field.dimension)
-    field.mode.foreach(v => builder.field("mode", v))
-    field.compressionLevel.foreach(v => builder.field("compression_level", v))
+    field.mode.foreach(v => builder.field("mode", v.name))
+    field.compressionLevel.foreach(v =>
+      builder.field("compression_level", v.name)
+    )
     // start of `method` field
     builder.startObject("method")
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KnnVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KnnVectorFieldBuilderFn.scala
@@ -15,9 +15,11 @@ import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 object KnnVectorFieldBuilderFn {
   def toField(name: String, values: Map[String, Any]): KnnVectorField = {
     KnnVectorField(
-      name,
-      values.get("dimension").map(_.asInstanceOf[Int]).get,
-      (values.get("method") match {
+      name = name,
+      dimension = values.get("dimension").map(_.asInstanceOf[Int]).get,
+      mode = values.get("mode").map(_.asInstanceOf[String]),
+      compressionLevel = values.get("compressionLevel").map(_.asInstanceOf[String]),
+      parameters = (values.get("method") match {
         case Some(v) =>
           val methodFields: Map[String, Any] = v.asInstanceOf[Map[String, Any]]
           val methodName = methodFields.get("name").map(_.asInstanceOf[String])
@@ -152,7 +154,8 @@ object KnnVectorFieldBuilderFn {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)
     builder.field("dimension", field.dimension)
-
+    field.mode.foreach(v => builder.field("mode", v))
+    field.compressionLevel.foreach(v => builder.field("compression_level", v))
     // start of `method` field
     builder.startObject("method")
 


### PR DESCRIPTION
Add support for on_disk vector workload mode for OpenSearch KNN fields, as described in https://github.com/magda-io/magda/issues/3596.